### PR TITLE
Feat: 칼럼 모달에 사용되는 버튼,인풋 디자인 구현.

### DIFF
--- a/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnButton.tsx
+++ b/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnButton.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { mediaBreakpoint } from '@styles/mediaBreakpoint';
+import styled from 'styled-components';
+
+interface Props {
+  text: string;
+}
+//text prop에 버튼이름을 주면 됨.
+export default function ColumnButton({ text }: Props) {
+  return <S.CreateButton text={text}>{text}</S.CreateButton>;
+}
+
+const S = {
+  CreateButton: styled.div<Props>`
+    background-color: ${({ text, theme }) => (text === '취소' ? theme.color.white_FFFFFF : theme.color.violet_5534DA)};
+    color: ${({ text, theme }) => (text === '취소' ? theme.color.gray_787486 : theme.color.white_FFFFFF)};
+    font-size: 1.4rem;
+    font-weight: 500;
+    width: 13.8rem;
+    height: 4.2rem;
+    border-radius: 0.8rem;
+    border: 1px solid ${({ text, theme }) => (text === '취소' ? theme.color.gray_D9D9D9 : '')};
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    @media ${mediaBreakpoint.tablet} {
+      font-size: 1.6rem;
+      width: 12rem;
+      height: 4.8rem;
+    }
+  `,
+};

--- a/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnButton.tsx
+++ b/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnButton.tsx
@@ -3,16 +3,16 @@
 import { mediaBreakpoint } from '@styles/mediaBreakpoint';
 import styled from 'styled-components';
 
-interface Props {
+interface ColumnButtonProps {
   text: string;
 }
 //text prop에 버튼이름을 주면 됨.
-export default function ColumnButton({ text }: Props) {
+export default function ColumnButton({ text }: ColumnButtonProps) {
   return <S.CreateButton text={text}>{text}</S.CreateButton>;
 }
 
 const S = {
-  CreateButton: styled.div<Props>`
+  CreateButton: styled.div<ColumnButtonProps>`
     background-color: ${({ text, theme }) => (text === '취소' ? theme.color.white_FFFFFF : theme.color.violet_5534DA)};
     color: ${({ text, theme }) => (text === '취소' ? theme.color.gray_787486 : theme.color.white_FFFFFF)};
     font-size: 1.4rem;

--- a/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnInput.tsx
+++ b/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnInput.tsx
@@ -7,18 +7,24 @@ import styled from 'styled-components';
 export default function ColumnInput() {
   return (
     <>
-      <form>
+      <S.ColumnForm>
         <S.ColumnLabel htmlFor='column-name'>이름</S.ColumnLabel>
         <S.ColumnInput id='column-name' type='text' placeholder='새로운 프로젝트' />
-      </form>
+      </S.ColumnForm>
     </>
   );
 }
 
 const S = {
+  ColumnForm: styled.form`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  `,
+
   ColumnInput: styled.input`
     color: ${({ theme }) => theme.color.black_333236};
-    border: 1px solid ${({ theme }) => theme.color.gray_D9D9D9};
+    border: 0.1rem solid ${({ theme }) => theme.color.gray_D9D9D9};
     border-radius: 0.6rem;
     font-size: 1.4rem;
 
@@ -28,7 +34,7 @@ const S = {
 
     &:focus {
       outline: none;
-      border: 1px solid ${({ theme }) => theme.color.violet_5534DA};
+      border: 0.1rem solid ${({ theme }) => theme.color.violet_5534DA};
     }
 
     @media ${mediaBreakpoint.tablet} {

--- a/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnInput.tsx
+++ b/app/dashboard/[dashboardId]/_column/_components/atoms/ColumnInput.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { mediaBreakpoint } from '@styles/mediaBreakpoint';
+import styled from 'styled-components';
+//Todo: validate 했을 때 디자인 추가 필요
+//기본적인 디자인, 틀만 완성
+export default function ColumnInput() {
+  return (
+    <>
+      <form>
+        <S.ColumnLabel htmlFor='column-name'>이름</S.ColumnLabel>
+        <S.ColumnInput id='column-name' type='text' placeholder='새로운 프로젝트' />
+      </form>
+    </>
+  );
+}
+
+const S = {
+  ColumnInput: styled.input`
+    color: ${({ theme }) => theme.color.black_333236};
+    border: 1px solid ${({ theme }) => theme.color.gray_D9D9D9};
+    border-radius: 0.6rem;
+    font-size: 1.4rem;
+
+    width: 28.7rem;
+    height: 4.2rem;
+    padding: 0 1.6rem;
+
+    &:focus {
+      outline: none;
+      border: 1px solid ${({ theme }) => theme.color.violet_5534DA};
+    }
+
+    @media ${mediaBreakpoint.tablet} {
+      font-size: 1.6rem;
+      width: 48.4rem;
+      height: 4.8rem;
+    }
+  `,
+  ColumnLabel: styled.label`
+    font-size: 1.6rem;
+    font-weight: 500;
+    color: ${({ theme }) => theme.color.black_333236};
+
+    @media ${mediaBreakpoint.tablet} {
+      font-size: 1.8rem;
+    }
+  `,
+};

--- a/app/dashboard/[dashboardId]/page.tsx
+++ b/app/dashboard/[dashboardId]/page.tsx
@@ -1,0 +1,10 @@
+import ColumnButton from './_column/_components/atoms/ColumnButton';
+// 버튼 레이아웃 확인을 위해 잠시 ColumnButton 사용중
+export default function DashboardDetail() {
+  return (
+    <>
+      <ColumnButton text='생성' />
+      <ColumnButton text='취소' />
+    </>
+  );
+}

--- a/app/dashboard/[dashboardId]/page.tsx
+++ b/app/dashboard/[dashboardId]/page.tsx
@@ -1,10 +1,12 @@
 import ColumnButton from './_column/_components/atoms/ColumnButton';
+import ColumnInput from './_column/_components/atoms/ColumnInput';
 // 버튼 레이아웃 확인을 위해 잠시 ColumnButton 사용중
 export default function DashboardDetail() {
   return (
     <>
       <ColumnButton text='생성' />
       <ColumnButton text='취소' />
+      <ColumnInput />
     </>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
close #33 
> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
-  칼럼 모달에 사용되는 버튼, 인풋 디자인만 구현했습니다.
-  재사용 되는 컴포넌트는 atoms 폴더에 작성했습니다.
-  반응형 확인을 위해 잠시 dashboard/[dashboardId] page에 import해 놨습니다. 

### 스크린샷 (선택)
취소버튼만 디자인이 달라서 text로 "취소" 문자열을 받을때만 디자인이 달라지게 했습니다.
![스크린샷 2024-03-14 173938](https://github.com/GihoKo/taskify_team8/assets/81504945/f51f6fba-8d6e-4c4b-939f-0b2b32bb4d62)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 취소 버튼만 디자인이 달라서 text prop으로 버튼 이름?을 받아서 삼항연산자로 조건에 맞으면 색이 달라지게 했는데 이거 보다 더 좋은 방법이 있을까요?(잘 몰라서 여쭤봅니다.)
- dashboard/[dashboardId] 경로에 있는 모달이 할일과 칼럼이 있는데 폴더구조를 이렇게 해도 되는지 어떻게 하면 좋을 지 잘 모르겠습니다. 
저는 방법1로 했습니다. 칼럼과 할일을 분리해서 놔야할 것 같아서 이렇게 했는데 
같은 페이지에 있는 거니까 방법2처럼 해야하는건지 헷갈립니다. 아니면 또 다른 방법이 있을까요?

![스크린샷 2024-03-14 175209](https://github.com/GihoKo/taskify_team8/assets/81504945/4db2e20e-81d2-48eb-bd28-fce6a49252ad)


> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
